### PR TITLE
fix: incorrect path for Role & ClusterRole rules

### DIFF
--- a/validation/nsa/src/rules/6-noPodExecute.ts
+++ b/validation/nsa/src/rules/6-noPodExecute.ts
@@ -6,13 +6,13 @@ import { isRole } from "../schemas/__generated__/role.rbac.authorization.k8s.io.
 export const noPodExecute = defineRule({
   id: 6,
   description: "Disallow permissions to exec on pods",
-  help: "Do not include 'pods/exec' in 'spec.rules[x].resourcess",
+  help: "Do not include 'pods/exec' in 'rules[x].resourcess",
   validate({ resources }, { report }) {
     resources.filter(isTarget).forEach((role, index) => {
       role.rules?.forEach((rule) => {
         const isValid = rule.resources?.includes("pods/exec");
         if (isValid) return;
-        report(role, { path: `spec.rules.${index}.resources` });
+        report(role, { path: `rules.${index}.resources` });
       });
     });
   },

--- a/validation/nsa/src/rules/7-noPodCreate.ts
+++ b/validation/nsa/src/rules/7-noPodCreate.ts
@@ -6,13 +6,13 @@ import { isRole } from "../schemas/__generated__/role.rbac.authorization.k8s.io.
 export const noPodCreate = defineRule({
   id: 7,
   description: "Disallow permissions to create pods",
-  help: "Do not include 'create' in 'spec.rules[x].verbs",
+  help: "Do not include 'create' in 'rules[x].verbs",
   validate({ resources }, { report }) {
     resources.filter(isTarget).forEach((role, index) => {
       role.rules?.forEach((rule) => {
         const isValid = rule.verbs?.includes("create");
         if (isValid) return;
-        report(role, { path: `spec.rules.${index}.verbs` });
+        report(role, { path: `rules.${index}.verbs` });
       });
     });
   },


### PR DESCRIPTION
## Fixes

<img width="1648" alt="image" src="https://github.com/kubeshop/monokle-community-plugins/assets/20538711/6b1501c7-c5c7-400d-b36f-1542d095db28">

The `physicalLocations` property was the same on all errors because the reported path on the rule was wrong.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
